### PR TITLE
chore: Refactor userEnteredWorkshop to return void

### DIFF
--- a/app/lib/models/workshop.server.ts
+++ b/app/lib/models/workshop.server.ts
@@ -104,9 +104,9 @@ export async function getWorkshop(
 export async function userEnteredWorkshop(
   slug: string,
   request: any,
-): Promise<Workshop | null> {
+): Promise<void> {
   const token = await currentToken({ request });
-  const workshop = await axios
+  await axios
     .post(
       `${environment().API_HOST}/workshops/${slug}/user-entered`,
       {},
@@ -122,5 +122,4 @@ export async function userEnteredWorkshop(
         return null;
       }
     });
-  return workshop;
 }

--- a/app/routes/_layout-raw/_player/workshops_.$workshopSlug_.$slug/index.tsx
+++ b/app/routes/_layout-raw/_player/workshops_.$workshopSlug_.$slug/index.tsx
@@ -10,11 +10,11 @@ import type { Lesson } from "~/lib/models/lesson.server";
 import type { User } from "~/lib/models/user.server";
 import type { Workshop } from "~/lib/models/workshop.server";
 import { getWorkshop, userEnteredWorkshop } from "~/lib/models/workshop.server";
+import { getOgGeneratorUrl } from "~/lib/utils/path-utils";
 import { abort404 } from "~/lib/utils/responses.server";
 import MainContent from "../components/main-content";
 import Sidebar from "../components/sidebar";
 import styles from "../styles.css?url";
-import { getOgGeneratorUrl } from "~/lib/utils/path-utils";
 
 export function links() {
   return [{ rel: "stylesheet", href: styles }];
@@ -78,7 +78,7 @@ export async function loader({
     return abort404();
   }
 
-  await userEnteredWorkshop(workshop.slug, request);
+  userEnteredWorkshop(workshop.slug, request);
 
   return {
     workshop: workshop,


### PR DESCRIPTION
closes https://github.com/codante-io/roadmap/issues/425

```text
Refactor the userEnteredWorkshop function to return void instead of Promise<Workshop | null>. This change is made to align with the updated axios post request in the function. The workshop variable is no longer needed to be returned.
