### PR TITLE
refactor: Update useLazyLoading hook to accept refreshDeps parameter

### DIFF
--- a/app/lib/hooks/use-lazy-loading.tsx
+++ b/app/lib/hooks/use-lazy-loading.tsx
@@ -1,7 +1,7 @@
 import { useEffect } from "react";
 import LazyLoad from "vanilla-lazyload";
 
-export default function useLazyLoading() {
+export default function useLazyLoading(refreshDeps: any[] = []) {
   useEffect(() => {
     let lazyLoadInstance = new LazyLoad({
       elements_selector: ".lazy",
@@ -11,5 +11,5 @@ export default function useLazyLoading() {
     return () => {
       lazyLoadInstance.destroy();
     };
-  }, []);
+  }, [refreshDeps]);
 }

--- a/app/routes/_layout-app/_workshops/workshops/index.tsx
+++ b/app/routes/_layout-app/_workshops/workshops/index.tsx
@@ -68,7 +68,7 @@ export default function Workshops() {
       workshop.published_at && new Date(workshop.published_at) >= new Date(),
   );
 
-  useLazyLoading();
+  useLazyLoading([selectedTechs]);
 
   const technologies = [
     {


### PR DESCRIPTION
closes https://github.com/codante-io/roadmap/issues/435

The useLazyLoading hook has been updated to accept a refreshDeps parameter, allowing for more control over when the lazy loading behavior is triggered. This change improves the flexibility and reusability of the hook.
