### PR TITLE
Add public profile pages and avatar hover cards

### DIFF
--- a/app/components/_layouts/navbar/profile-menu.test.tsx
+++ b/app/components/_layouts/navbar/profile-menu.test.tsx
@@ -1,0 +1,55 @@
+import userEvent from "@testing-library/user-event";
+import { screen } from "@testing-library/react";
+import type { User } from "~/lib/models/user.server";
+import { renderWithRouter } from "~/test/render-with-router";
+import ProfileMenu from "./profile-menu";
+
+describe("ProfileMenu", () => {
+  const baseUser: User = {
+    id: 1,
+    name: "Ícaro Harry",
+    email: "icaro@example.com",
+    github_id: "123",
+    is_pro: true,
+    github_user: "icaroharry",
+    settings: null,
+    avatar: {
+      avatar_url: "https://example.com/avatar.jpg",
+      name: "Ícaro Harry",
+      badge: null,
+      github_user: "icaroharry",
+    },
+  };
+
+  it("shows a Meu Perfil link when the user has a github username", async () => {
+    const user = userEvent.setup();
+
+    renderWithRouter(() => <ProfileMenu user={baseUser} />);
+
+    await user.click(screen.getByRole("button"));
+
+    expect(
+      screen.getByRole("menuitem", { name: "Meu Perfil" }),
+    ).toHaveAttribute("href", "/perfil/icaroharry");
+  });
+
+  it("hides the Meu Perfil link when the user has no github username", async () => {
+    const user = userEvent.setup();
+    const userWithoutGithub = {
+      ...baseUser,
+      github_user: undefined,
+      avatar: {
+        ...baseUser.avatar,
+        github_user: undefined,
+      },
+    };
+
+    renderWithRouter(() => <ProfileMenu user={userWithoutGithub} />);
+
+    await user.click(screen.getByRole("button"));
+
+    expect(
+      screen.queryByRole("menuitem", { name: "Meu Perfil" }),
+    ).not.toBeInTheDocument();
+  });
+});

--- a/app/components/_layouts/navbar/profile-menu.tsx
+++ b/app/components/_layouts/navbar/profile-menu.tsx
@@ -7,6 +7,8 @@ import classNames from "~/lib/utils/class-names";
 import UserAvatar from "~/components/ui/user-avatar";
 
 export default function ProfileMenu({ user }: { user: User }) {
+  const githubUser = user.github_user ?? user.avatar?.github_user;
+
   return (
     <Menu as="div" className="relative z-50">
       <div>
@@ -65,6 +67,21 @@ export default function ProfileMenu({ user }: { user: User }) {
               </Link>
             )}
           </Menu.Item>
+          {githubUser && (
+            <Menu.Item>
+              {({ active }) => (
+                <Link
+                  to={`/perfil/${githubUser}`}
+                  className={classNames(
+                    active ? "dark:bg-background-800/50 bg-background-50" : "",
+                    "block px-4 py-2 text-sm dark:text-gray-50 text-gray-700",
+                  )}
+                >
+                  Meu Perfil
+                </Link>
+              )}
+            </Menu.Item>
+          )}
           <Menu.Item>
             {({ active }) => (
               <Form action="/logout" method="post">

--- a/app/components/ui/cards/challenge-card.test.tsx
+++ b/app/components/ui/cards/challenge-card.test.tsx
@@ -7,6 +7,12 @@ vi.mock("~/components/ui/tooltip", () => ({
   default: ({ children }: { children: React.ReactNode }) => <>{children}</>,
 }));
 
+vi.mock("~/components/ui/user-avatar-hover-card", () => ({
+  default: ({ children }: { children: React.ReactNode }) => (
+    <div data-testid="avatar-hover-card">{children}</div>
+  ),
+}));
+
 const mockChallenge = {
   id: 1,
   name: "Landing Page com Tailwind",
@@ -90,5 +96,18 @@ describe("ChallengeCard", () => {
     ));
     const link = screen.getByRole("link");
     expect(link.className).toContain("cursor-not-allowed");
+  });
+
+  it("does not render avatar hover cards by default", () => {
+    renderWithRouter(() => <ChallengeCard challenge={mockChallenge as any} />);
+    expect(screen.queryByTestId("avatar-hover-card")).not.toBeInTheDocument();
+  });
+
+  it("renders avatar hover cards when enabled", () => {
+    renderWithRouter(() => (
+      <ChallengeCard challenge={mockChallenge as any} showAvatarHoverCard />
+    ));
+
+    expect(screen.getAllByTestId("avatar-hover-card")).toHaveLength(2);
   });
 });

--- a/app/components/ui/cards/challenge-card.tsx
+++ b/app/components/ui/cards/challenge-card.tsx
@@ -3,6 +3,7 @@ import type { ChallengeCard as ChallengeCardType } from "~/lib/models/challenge.
 
 import classNames from "~/lib/utils/class-names";
 import UserAvatar from "../user-avatar";
+import UserAvatarHoverCard from "~/components/ui/user-avatar-hover-card";
 import CardItemLevel from "~/components/ui/cards/card-item-level";
 import CardItemMainTechnology from "~/components/ui/cards/card-item-main-technology";
 import { ArrowRight } from "lucide-react";
@@ -13,10 +14,12 @@ export default function ChallengeCard({
   challenge,
   className = "",
   openInNewTab,
+  showAvatarHoverCard = false,
 }: {
   challenge: ChallengeCardType;
   openInNewTab?: boolean;
   className?: string;
+  showAvatarHoverCard?: boolean;
 }) {
   return (
     <Link
@@ -75,13 +78,28 @@ export default function ChallengeCard({
           <div className="flex justify-between w-full mt-8 gap-1 border-t border-gray-200 dark:border-gray-800 pt-4">
             <section className="flex items-center">
               <div className="flex -space-x-[9px]">
-                {challenge?.avatars?.map((avatar, index) => (
-                  <UserAvatar
-                    key={index}
-                    avatar={avatar}
-                    className="size-7 rounded-full ring-2 ring-white dark:ring-background-800"
-                  />
-                ))}
+                {challenge?.avatars?.map((avatar, index) =>
+                  showAvatarHoverCard ? (
+                    <UserAvatarHoverCard
+                      key={index}
+                      avatar={avatar}
+                      profileTarget={openInNewTab ? "_blank" : "_self"}
+                    >
+                      <UserAvatar
+                        avatar={avatar}
+                        className="size-7 rounded-full ring-2 ring-white dark:ring-background-800"
+                        showTooltip={false}
+                      />
+                    </UserAvatarHoverCard>
+                  ) : (
+                    <UserAvatar
+                      key={index}
+                      avatar={avatar}
+                      className="size-7 rounded-full ring-2 ring-white dark:ring-background-800"
+                      showTooltip={false}
+                    />
+                  ),
+                )}
                 {challenge.enrolled_users_count > 5 && (
                   <div className="flex size-7 items-center justify-center rounded-full bg-blue-100 text-[9px] font-medium text-blue-800 ring-2 ring-white dark:ring-background-800 dark:bg-blue-900 dark:text-blue-200">
                     +{challenge.enrolled_users_count - 5}

--- a/app/components/ui/user-avatar-hover-card/index.tsx
+++ b/app/components/ui/user-avatar-hover-card/index.tsx
@@ -1,0 +1,166 @@
+import { Link, useFetcher } from "react-router";
+import { useRef, useState, useEffect, useCallback } from "react";
+import { createPortal } from "react-dom";
+import { BsFillHeartFill, BsTools } from "react-icons/bs";
+import { FaMedal } from "react-icons/fa";
+import type { UserAvatar, UserProfile } from "~/lib/models/user.server";
+import { useMediaQuery } from "~/lib/hooks/use-media-query";
+import { formatName } from "~/lib/utils/format-name";
+import ProBadge from "~/components/ui/pro-badge";
+
+export default function UserAvatarHoverCard({
+  avatar,
+  children,
+  profileTarget = "_self",
+}: {
+  avatar: UserAvatar;
+  children: React.ReactNode;
+  profileTarget?: "_self" | "_blank";
+}) {
+  const isMobile = useMediaQuery("(max-width: 768px)");
+  const fetcher = useFetcher<UserProfile>();
+  const [isOpen, setIsOpen] = useState(false);
+  const [hasLoaded, setHasLoaded] = useState(false);
+  const [position, setPosition] = useState({ top: 0, left: 0 });
+  const triggerRef = useRef<HTMLSpanElement>(null);
+  const timeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  const openCard = useCallback(() => {
+    if (timeoutRef.current) clearTimeout(timeoutRef.current);
+    timeoutRef.current = setTimeout(() => {
+      if (triggerRef.current) {
+        const rect = triggerRef.current.getBoundingClientRect();
+        setPosition({
+          top: rect.top + window.scrollY - 8,
+          left: rect.left + window.scrollX + rect.width / 2,
+        });
+      }
+      setIsOpen(true);
+      if (!hasLoaded && avatar.github_user && fetcher.state === "idle") {
+        fetcher.load(`/user-profile?github_user=${avatar.github_user}`);
+        setHasLoaded(true);
+      }
+    }, 300);
+  }, [hasLoaded, avatar.github_user, fetcher]);
+
+  const closeCard = useCallback(() => {
+    if (timeoutRef.current) clearTimeout(timeoutRef.current);
+    timeoutRef.current = setTimeout(() => {
+      setIsOpen(false);
+    }, 200);
+  }, []);
+
+  const keepOpen = useCallback(() => {
+    if (timeoutRef.current) clearTimeout(timeoutRef.current);
+  }, []);
+
+  useEffect(() => {
+    return () => {
+      if (timeoutRef.current) clearTimeout(timeoutRef.current);
+    };
+  }, []);
+
+  if (isMobile || !avatar.github_user) {
+    return <>{children}</>;
+  }
+
+  const profile = fetcher.data;
+
+  return (
+    <>
+      <span
+        ref={triggerRef}
+        onMouseEnter={openCard}
+        onMouseLeave={closeCard}
+        className="relative z-10"
+      >
+        {children}
+      </span>
+      {isOpen &&
+        typeof document !== "undefined" &&
+        createPortal(
+          <div
+            onMouseEnter={keepOpen}
+            onMouseLeave={closeCard}
+            style={{
+              position: "absolute",
+              top: position.top,
+              left: position.left,
+              transform: "translate(-50%, -100%)",
+              zIndex: 9999,
+            }}
+            className="animate-in fade-in-0 zoom-in-95 duration-150"
+          >
+            <div className="w-64 rounded-xl border border-background-200 dark:border-background-600 bg-background-50 dark:bg-background-800 p-4 shadow-xl">
+              <Link
+                to={`/perfil/${avatar.github_user}`}
+                prefetch="intent"
+                target={profileTarget}
+                rel={profileTarget === "_blank" ? "noreferrer" : undefined}
+                className="block"
+                onClick={(e) => e.stopPropagation()}
+              >
+                <div className="flex items-center gap-3 mb-3">
+                  <img
+                    src={
+                      avatar.avatar_url ||
+                      "https://screenshot-service1.codante.io/avatars/sm"
+                    }
+                    alt={avatar.name}
+                    className={`w-10 h-10 rounded-full bg-background-400 shrink-0 ${
+                      avatar.badge === "pro"
+                        ? "ring-2 ring-amber-400"
+                        : avatar.badge === "admin"
+                          ? "ring-2 ring-brand-500"
+                          : "ring-2 ring-white dark:ring-gray-700"
+                    }`}
+                  />
+                  <div className="min-w-0">
+                    <div className="flex items-center gap-1">
+                      <span className="text-sm font-semibold text-gray-800 dark:text-gray-100 truncate">
+                        {formatName(avatar.name)}
+                      </span>
+                      {avatar.badge === "pro" && <ProBadge />}
+                    </div>
+                    <span className="text-xs text-gray-400 dark:text-gray-500">
+                      @{avatar.github_user}
+                    </span>
+                  </div>
+                </div>
+
+                {fetcher.state === "loading" && (
+                  <div className="flex gap-4 animate-pulse">
+                    <div className="h-4 w-16 rounded bg-background-200 dark:bg-background-700" />
+                    <div className="h-4 w-16 rounded bg-background-200 dark:bg-background-700" />
+                    <div className="h-4 w-16 rounded bg-background-200 dark:bg-background-700" />
+                  </div>
+                )}
+
+                {profile && (
+                  <div className="flex items-center gap-4 text-xs text-gray-500 dark:text-gray-400">
+                    <span className="flex items-center gap-1">
+                      <BsTools className="w-3 h-3 text-brand-500" />
+                      {profile.stats.completed_challenge_count}
+                    </span>
+                    <span className="flex items-center gap-1">
+                      <BsFillHeartFill className="w-3 h-3 text-brand-500" />
+                      {profile.stats.received_reaction_count}
+                    </span>
+                    <span className="flex items-center gap-1">
+                      <FaMedal className="w-3 h-3 text-brand-500" />
+                      {profile.stats.points}
+                    </span>
+                  </div>
+                )}
+
+                <span className="mt-2 block text-[10px] text-brand-400 hover:underline">
+                  Ver perfil completo
+                </span>
+              </Link>
+            </div>
+          </div>,
+          document.body,
+        )}
+    </>
+  );
+}

--- a/app/lib/models/user.server.ts
+++ b/app/lib/models/user.server.ts
@@ -53,6 +53,59 @@ export type UserAvatar = {
   github_user?: string;
 };
 
+export type UserProfile = {
+  user: {
+    name: string;
+    github_user: string;
+    linkedin_user: string | null;
+    avatar: UserAvatar;
+    created_at: string;
+  };
+  stats: {
+    points: number;
+    completed_challenge_count: number;
+    received_reaction_count: number;
+  };
+  completed_challenges: ProfileChallengeSubmission[];
+  certificates: ProfileCertificate[];
+};
+
+export type ProfileChallengeSubmission = {
+  id: number;
+  submission_image_url: string;
+  submission_url: string;
+  submitted_at: string;
+  challenge: {
+    name: string;
+    slug: string;
+    image_url: string;
+  };
+};
+
+export type ProfileCertificate = {
+  id: string;
+  metadata: {
+    certifiable_source_name: string;
+    certifiable_slug: string;
+    [key: string]: unknown;
+  };
+  status: string;
+  created_at: string;
+};
+
+export async function getUserProfile(
+  githubUser: string,
+): Promise<UserProfile | null> {
+  const axios = await createAxios();
+  return axios
+    .get(`/users/${githubUser}/profile`)
+    .then((res) => res.data.data)
+    .catch((e) => {
+      if (e.response?.status === 404) return null;
+      throw e;
+    });
+}
+
 export async function impersonate(
   request: any,
   userId: string,

--- a/app/lib/services/auth.server.ts
+++ b/app/lib/services/auth.server.ts
@@ -107,10 +107,15 @@ export async function logout({
 
   const user = session.get("user");
 
-  if (!user?.token) return redirect(redirectTo);
-  const axios = await createAxios(request);
+  if (user?.token) {
+    const axios = await createAxios(request);
 
-  await axios.post("/logout");
+    try {
+      await axios.post("/logout");
+    } catch {
+      // Even if the API token is already invalid, we still need to clear the app session.
+    }
+  }
 
   return redirect(redirectTo, {
     headers: {
@@ -134,9 +139,13 @@ export async function logoutWithRedirectAfterLogin({
 
   const user = session.get("user");
 
-  if (!user?.token) return redirect(`/login?redirectTo=${redirectTo}`);
-
-  await axios.post("/logout");
+  if (user?.token) {
+    try {
+      await axios.post("/logout");
+    } catch {
+      // We still want to drop the local session and continue the re-login flow.
+    }
+  }
 
   return redirect(`/login?redirectTo=${redirectTo}`, {
     headers: {

--- a/app/lib/services/github-auth.server.ts
+++ b/app/lib/services/github-auth.server.ts
@@ -1,5 +1,6 @@
 import { Authenticator } from "remix-auth";
 import { GitHubStrategy } from "remix-auth-github";
+import { isAxiosError } from "axios";
 import { environment } from "~/lib/models/environment";
 import { createAxios } from "~/lib/services/axios.server";
 
@@ -15,13 +16,28 @@ const gitHubStrategy = new GitHubStrategy(
   async (params) => {
     const axios = await createAxios();
 
-    const res = await axios.post("/github-login", {
-      github_token: params.tokens.accessToken(),
-    });
-    const token = res.data.token;
+    try {
+      const res = await axios.post("/github-login", {
+        github_token: params.tokens.accessToken(),
+      });
+      const token = res.data.token;
 
-    // Vamos enviar o token e o is_new_signup value para o cliente
-    return { token: token, is_new_signup: res.data.is_new_signup };
+      // Vamos enviar o token e o is_new_signup value para o cliente
+      return { token: token, is_new_signup: res.data.is_new_signup };
+    } catch (error) {
+      if (isAxiosError(error)) {
+        const status = error.response?.status ?? "unknown";
+        const data = error.response?.data;
+        const backendMessage =
+          (typeof data?.error === "string" && data.error) ||
+          (typeof data?.message === "string" && data.message) ||
+          error.message;
+
+        throw new Error(`GitHub login failed (${status}): ${backendMessage}`);
+      }
+
+      throw error;
+    }
   },
 );
 

--- a/app/routes/_api/user-profile/index.tsx
+++ b/app/routes/_api/user-profile/index.tsx
@@ -1,0 +1,21 @@
+import type { LoaderFunctionArgs } from "react-router";
+import { getUserProfile } from "~/lib/models/user.server";
+
+export async function loader({ request }: LoaderFunctionArgs) {
+  const url = new URL(request.url);
+  const githubUser = url.searchParams.get("github_user");
+
+  if (!githubUser) {
+    return Response.json(null, { status: 400 });
+  }
+
+  const profile = await getUserProfile(githubUser);
+
+  if (!profile) {
+    return Response.json(null, { status: 404 });
+  }
+
+  return Response.json(profile, {
+    headers: { "Cache-Control": "public, max-age=300" },
+  });
+}

--- a/app/routes/_landing-page/components/headline/avatars.test.tsx
+++ b/app/routes/_landing-page/components/headline/avatars.test.tsx
@@ -1,0 +1,48 @@
+import { render, screen } from "@testing-library/react";
+import type { User } from "~/lib/models/user.server";
+import AvatarsSection from "./avatars";
+
+vi.mock("~/components/ui/user-avatar-hover-card", () => ({
+  default: ({ children }: { children: React.ReactNode }) => (
+    <div data-testid="avatar-hover-card">{children}</div>
+  ),
+}));
+
+vi.mock("~/components/ui/tooltip", () => ({
+  default: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}));
+
+describe("AvatarsSection", () => {
+  const user: User = {
+    id: 1,
+    name: "Maria",
+    email: "maria@example.com",
+    github_id: "123",
+    is_pro: false,
+    avatar: {
+      name: "Maria",
+      avatar_url: "https://example.com/maria.jpg",
+      badge: null,
+      github_user: "maria",
+    },
+    settings: null,
+    github_user: "maria",
+  };
+
+  const avatars = [
+    user.avatar,
+    {
+      name: "Bruno",
+      avatar_url: "https://example.com/bruno.jpg",
+      badge: "pro" as const,
+      github_user: "bruno",
+    },
+  ];
+
+  it("renders avatar hover cards for the hero avatars", () => {
+    render(<AvatarsSection user={user} avatars={avatars} userCount={6513} />);
+
+    expect(screen.getAllByTestId("avatar-hover-card")).toHaveLength(2);
+    expect(screen.getByText("6513 devs")).toBeInTheDocument();
+  });
+});

--- a/app/routes/_landing-page/components/headline/avatars.tsx
+++ b/app/routes/_landing-page/components/headline/avatars.tsx
@@ -1,5 +1,6 @@
 import { User, UserAvatar } from "~/lib/models/user.server";
 import Avatar from "~/components/ui/user-avatar";
+import UserAvatarHoverCard from "~/components/ui/user-avatar-hover-card";
 
 function AvatarsSection({
   user,
@@ -10,35 +11,32 @@ function AvatarsSection({
   avatars: UserAvatar[];
   userCount: number;
 }) {
+  const avatarClassName = "xl:w-9 xl:h-9 lg:h-[30px] lg:w-[30px] w-9 h-9";
+
+  function renderAvatar(avatar: UserAvatar, key: string) {
+    return (
+      <UserAvatarHoverCard key={key} avatar={avatar} profileTarget="_blank">
+        <Avatar
+          avatar={avatar}
+          className={avatarClassName}
+          showTooltip={false}
+        />
+      </UserAvatarHoverCard>
+    );
+  }
+
   return (
     <div className="flex items-start flex-col md:flex-row justify-start w-full mt-10 gap-4">
       <div className="flex -space-x-3">
-        {user && (
-          <Avatar
-            avatar={user.avatar}
-            className="xl:w-9 xl:h-9 lg:h-[30px] lg:w-[30px] w-9 h-9"
-          />
-        )}
+        {user && renderAvatar(user.avatar, `current-user-${user.id}`)}
         {user
           ? avatars
               .filter((avatar) => avatar.avatar_url !== user.avatar.avatar_url)
               .slice(0, 8)
-              .map((avatar, index) => (
-                <Avatar
-                  key={index}
-                  avatar={avatar}
-                  className="xl:w-9 xl:h-9 lg:h-[30px] lg:w-[30px] w-9 h-9"
-                />
-              ))
+              .map((avatar, index) => renderAvatar(avatar, `avatar-${index}`))
           : avatars
               .slice(0, 9)
-              .map((avatar, index) => (
-                <Avatar
-                  key={index}
-                  avatar={avatar}
-                  className="xl:w-9 xl:h-9 lg:h-[30px] lg:w-[30px] w-9 h-9"
-                />
-              ))}
+              .map((avatar, index) => renderAvatar(avatar, `avatar-${index}`))}
       </div>
       <h3 className="text-start text-xs font-inter dark:text-gray-300 text-gray-800 w-64">
         <b className=" inline-block dark:bg-background-700 bold border dark:border-background-600 bg-background-100 border-background-150 px-1 rotate-1 rounded-lg">

--- a/app/routes/_layout-app/_auth/login/index.test.ts
+++ b/app/routes/_layout-app/_auth/login/index.test.ts
@@ -1,0 +1,44 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { mockLogin, mockUser } = vi.hoisted(() => ({
+  mockLogin: vi.fn(),
+  mockUser: vi.fn(),
+}));
+
+vi.mock("~/lib/services/auth.server", () => ({
+  login: mockLogin,
+  user: mockUser,
+}));
+
+import { loader } from "./index";
+
+describe("login loader", () => {
+  beforeEach(() => {
+    mockLogin.mockReset();
+    mockUser.mockReset();
+  });
+
+  it("redirects authenticated users to home", async () => {
+    mockUser.mockResolvedValue({
+      id: 1,
+      name: "Maria",
+    });
+
+    const response = await loader({
+      request: new Request("http://localhost/login?redirectTo=/dashboard"),
+    } as any);
+
+    expect(response.status).toBe(302);
+    expect(response.headers.get("Location")).toBe("/");
+  });
+
+  it("allows guests to open the login page even when redirectTo is present", async () => {
+    mockUser.mockResolvedValue(null);
+
+    const response = await loader({
+      request: new Request("http://localhost/login?redirectTo=/dashboard"),
+    } as any);
+
+    expect(response).toEqual({ redirectTo: "/dashboard" });
+  });
+});

--- a/app/routes/_layout-app/_auth/login/index.tsx
+++ b/app/routes/_layout-app/_auth/login/index.tsx
@@ -10,7 +10,7 @@ import {
 } from "react-router";
 import { useState } from "react";
 import { useColorMode } from "~/lib/contexts/color-mode-context";
-import { login, sessionStorage } from "~/lib/services/auth.server";
+import { login, user as getUser } from "~/lib/services/auth.server";
 import AuthCard from "../auth-card";
 import LoadingButton from "~/components/features/form/loading-button";
 import type { LoaderFunctionArgs } from "react-router";
@@ -59,15 +59,12 @@ export async function action({ request }: { request: Request }) {
 }
 
 export async function loader({ request }: LoaderFunctionArgs) {
-  // await authenticator.isAuthenticated(request, {
-  //   successRedirect: "/",
-  // });
+  const user = await getUser({ request });
 
-  const session = await sessionStorage.getSession(
-    request.headers.get("Cookie"),
-  );
+  if (user instanceof Response) {
+    return user;
+  }
 
-  const user = session.get("user");
   if (user) {
     return redirect("/");
   }

--- a/app/routes/_layout-app/_mini-projetos/mini-projetos/featured-challenge-section.tsx
+++ b/app/routes/_layout-app/_mini-projetos/mini-projetos/featured-challenge-section.tsx
@@ -49,6 +49,7 @@ export default function FeaturedChallengeSection({
             <ChallengeCard
               className="shadow-[7px_7px_20px_0px_rgba(255,255,255,0.10)] dark:hover:shadow-[7px_7px_20px_0px_rgba(255,255,255,0.20)]"
               challenge={featuredChallenge}
+              showAvatarHoverCard
             />
           </div>
         </div>

--- a/app/routes/_layout-app/_mini-projetos/mini-projetos/index.tsx
+++ b/app/routes/_layout-app/_mini-projetos/mini-projetos/index.tsx
@@ -118,7 +118,11 @@ export default function ChallengesIndex() {
               </h2>
               <div className="grid grid-cols-1 md:grid-cols-2 gap-6 lg:grid-cols-3 xl:grid-cols-4 auto-rows-min">
                 {groupedChallenges.map((challenge: ChallengeCardType) => (
-                  <ChallengeCard key={challenge.id} challenge={challenge} />
+                  <ChallengeCard
+                    key={challenge.id}
+                    challenge={challenge}
+                    showAvatarHoverCard
+                  />
                 ))}
               </div>
             </div>

--- a/app/routes/_layout-app/_perfil/components/profile-certificates.tsx
+++ b/app/routes/_layout-app/_perfil/components/profile-certificates.tsx
@@ -1,0 +1,43 @@
+import { Link } from "react-router";
+import type { ProfileCertificate } from "~/lib/models/user.server";
+import { formatDate } from "~/lib/utils/format-date";
+
+export default function ProfileCertificates({
+  certificates,
+}: {
+  certificates: ProfileCertificate[];
+}) {
+  return (
+    <section className="mt-12">
+      <h2 className="text-xl font-bold font-lexend dark:text-gray-50 mb-6">
+        Certificados
+      </h2>
+      {certificates.length === 0 ? (
+        <p className="text-gray-500 dark:text-gray-400">
+          Nenhum certificado ainda.
+        </p>
+      ) : (
+        <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3">
+          {certificates.map((cert) => (
+            <Link
+              key={cert.id}
+              to={`/certificados/${cert.id}`}
+              prefetch="intent"
+              className="flex items-center gap-4 rounded-xl border border-background-200 dark:border-background-600 bg-background-50 dark:bg-background-800 p-4 hover:border-background-500 hover:shadow-lg transition-all"
+            >
+              <div className="flex-shrink-0 text-2xl">📜</div>
+              <div>
+                <h3 className="text-sm font-medium text-gray-700 dark:text-gray-200">
+                  {cert.metadata?.certifiable_source_name ?? "Certificado"}
+                </h3>
+                <p className="text-xs text-gray-400 dark:text-gray-500">
+                  {formatDate(cert.created_at)}
+                </p>
+              </div>
+            </Link>
+          ))}
+        </div>
+      )}
+    </section>
+  );
+}

--- a/app/routes/_layout-app/_perfil/components/profile-challenges.tsx
+++ b/app/routes/_layout-app/_perfil/components/profile-challenges.tsx
@@ -1,0 +1,57 @@
+import { Link } from "react-router";
+import type { ProfileChallengeSubmission } from "~/lib/models/user.server";
+
+export default function ProfileChallenges({
+  challenges,
+  githubUser,
+}: {
+  challenges: ProfileChallengeSubmission[];
+  githubUser: string;
+}) {
+  return (
+    <section className="mt-12">
+      <h2 className="text-xl font-bold font-lexend dark:text-gray-50 mb-6">
+        Mini Projetos Concluídos
+      </h2>
+      {challenges.length === 0 ? (
+        <p className="text-gray-500 dark:text-gray-400">
+          Nenhum mini-projeto concluído ainda.
+        </p>
+      ) : (
+        <div className="grid grid-cols-1 gap-6 sm:grid-cols-2 lg:grid-cols-3">
+          {challenges.map((submission) => (
+            <Link
+              key={submission.id}
+              to={`/mini-projetos/${submission.challenge.slug}/submissoes/${githubUser}`}
+              prefetch="intent"
+              className="group overflow-hidden rounded-xl border border-background-200 dark:border-background-600 bg-background-50 dark:bg-background-800 hover:border-background-500 hover:shadow-lg transition-all"
+            >
+              <div className="aspect-video overflow-hidden bg-background-200 dark:bg-background-700">
+                {submission.submission_image_url ? (
+                  <img
+                    src={submission.submission_image_url}
+                    alt={submission.challenge.name}
+                    className="w-full h-full object-cover group-hover:scale-105 transition-transform duration-300"
+                  />
+                ) : (
+                  <div className="flex items-center justify-center w-full h-full">
+                    <img
+                      src={submission.challenge.image_url}
+                      alt={submission.challenge.name}
+                      className="h-20 object-contain"
+                    />
+                  </div>
+                )}
+              </div>
+              <div className="p-4">
+                <h3 className="text-sm font-medium text-gray-700 dark:text-gray-200 line-clamp-2">
+                  {submission.challenge.name}
+                </h3>
+              </div>
+            </Link>
+          ))}
+        </div>
+      )}
+    </section>
+  );
+}

--- a/app/routes/_layout-app/_perfil/components/profile-header.test.tsx
+++ b/app/routes/_layout-app/_perfil/components/profile-header.test.tsx
@@ -1,0 +1,72 @@
+import { render, screen } from "@testing-library/react";
+import { MemoryRouter } from "react-router";
+import ProfileHeader from "./profile-header";
+
+// Mock Tooltip for UserAvatar
+vi.mock("~/components/ui/tooltip", () => ({
+  default: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}));
+
+const mockUser = {
+  name: "joão silva",
+  github_user: "joaosilva",
+  linkedin_user: "joao-silva",
+  avatar: {
+    avatar_url: "https://example.com/avatar.jpg",
+    name: "João Silva",
+    badge: "pro" as const,
+    github_user: "joaosilva",
+  },
+  created_at: "2024-01-15T12:00:00Z",
+};
+
+describe("ProfileHeader", () => {
+  const renderHeader = (user = mockUser) =>
+    render(
+      <MemoryRouter>
+        <ProfileHeader user={user} />
+      </MemoryRouter>,
+    );
+
+  it("renders the user name formatted", () => {
+    renderHeader();
+    expect(screen.getByText("João Silva")).toBeInTheDocument();
+  });
+
+  it("renders PRO badge for pro users", () => {
+    renderHeader();
+    expect(screen.getByText("PRO")).toBeInTheDocument();
+  });
+
+  it("does not render PRO badge when badge is null", () => {
+    renderHeader({
+      ...mockUser,
+      avatar: { ...mockUser.avatar, badge: null },
+    });
+    expect(screen.queryByText("PRO")).not.toBeInTheDocument();
+  });
+
+  it("renders GitHub link", () => {
+    renderHeader();
+    const link = screen.getByText("@joaosilva").closest("a");
+    expect(link).toHaveAttribute("href", "https://github.com/joaosilva");
+    expect(link).toHaveAttribute("target", "_blank");
+  });
+
+  it("renders LinkedIn link when present", () => {
+    renderHeader();
+    const link = screen.getByText("LinkedIn").closest("a");
+    expect(link).toHaveAttribute("href", "https://linkedin.com/in/joao-silva");
+  });
+
+  it("hides LinkedIn link when null", () => {
+    renderHeader({ ...mockUser, linkedin_user: null });
+    expect(screen.queryByText("LinkedIn")).not.toBeInTheDocument();
+  });
+
+  it("renders member since date", () => {
+    renderHeader();
+    expect(screen.getByText(/Membro desde/)).toBeInTheDocument();
+    expect(screen.getByText(/janeiro/)).toBeInTheDocument();
+  });
+});

--- a/app/routes/_layout-app/_perfil/components/profile-header.tsx
+++ b/app/routes/_layout-app/_perfil/components/profile-header.tsx
@@ -1,0 +1,55 @@
+import { FaGithub, FaLinkedin } from "react-icons/fa";
+import UserAvatar from "~/components/ui/user-avatar";
+import ProBadge from "~/components/ui/pro-badge";
+import { formatName } from "~/lib/utils/format-name";
+import { formatDate } from "~/lib/utils/format-date";
+import type { UserProfile } from "~/lib/models/user.server";
+
+export default function ProfileHeader({ user }: { user: UserProfile["user"] }) {
+  return (
+    <section className="flex flex-col items-center gap-4 md:flex-row md:items-start md:gap-8">
+      <UserAvatar
+        avatar={user.avatar}
+        className="w-24 h-24"
+        showTooltip={false}
+      />
+      <div className="flex flex-col items-center md:items-start gap-2">
+        <div className="flex items-center gap-2">
+          <h1 className="text-3xl font-bold font-lexend dark:text-gray-50">
+            {formatName(user.name)}
+          </h1>
+          {user.avatar.badge === "pro" && <ProBadge />}
+        </div>
+
+        <div className="flex items-center gap-4 text-sm text-gray-500 dark:text-gray-400">
+          {user.github_user && (
+            <a
+              href={`https://github.com/${user.github_user}`}
+              target="_blank"
+              rel="noreferrer"
+              className="flex items-center gap-1 hover:text-gray-700 dark:hover:text-gray-200"
+            >
+              <FaGithub className="w-4 h-4" />
+              <span>@{user.github_user}</span>
+            </a>
+          )}
+          {user.linkedin_user && (
+            <a
+              href={`https://linkedin.com/in/${user.linkedin_user}`}
+              target="_blank"
+              rel="noreferrer"
+              className="flex items-center gap-1 hover:text-gray-700 dark:hover:text-gray-200"
+            >
+              <FaLinkedin className="w-4 h-4" />
+              <span>LinkedIn</span>
+            </a>
+          )}
+        </div>
+
+        <p className="text-sm text-gray-400 dark:text-gray-500">
+          Membro desde {formatDate(user.created_at)}
+        </p>
+      </div>
+    </section>
+  );
+}

--- a/app/routes/_layout-app/_perfil/components/profile-stats.test.tsx
+++ b/app/routes/_layout-app/_perfil/components/profile-stats.test.tsx
@@ -1,0 +1,46 @@
+import { render, screen } from "@testing-library/react";
+import ProfileStats from "./profile-stats";
+
+describe("ProfileStats", () => {
+  const mockStats = {
+    points: 250,
+    completed_challenge_count: 12,
+    received_reaction_count: 45,
+  };
+
+  it("renders challenge count", () => {
+    render(<ProfileStats stats={mockStats} />);
+    expect(screen.getByText("12")).toBeInTheDocument();
+  });
+
+  it("renders reaction count", () => {
+    render(<ProfileStats stats={mockStats} />);
+    expect(screen.getByText("45")).toBeInTheDocument();
+  });
+
+  it("renders points", () => {
+    render(<ProfileStats stats={mockStats} />);
+    expect(screen.getByText("250")).toBeInTheDocument();
+  });
+
+  it("renders labels in Portuguese", () => {
+    render(<ProfileStats stats={mockStats} />);
+    expect(screen.getByText("mini-projetos concluídos")).toBeInTheDocument();
+    expect(screen.getByText("reações recebidas")).toBeInTheDocument();
+    expect(screen.getByText("pontos")).toBeInTheDocument();
+  });
+
+  it("renders zero values correctly", () => {
+    render(
+      <ProfileStats
+        stats={{
+          points: 0,
+          completed_challenge_count: 0,
+          received_reaction_count: 0,
+        }}
+      />,
+    );
+    const zeros = screen.getAllByText("0");
+    expect(zeros).toHaveLength(3);
+  });
+});

--- a/app/routes/_layout-app/_perfil/components/profile-stats.tsx
+++ b/app/routes/_layout-app/_perfil/components/profile-stats.tsx
@@ -1,0 +1,51 @@
+import { BsFillHeartFill, BsTools } from "react-icons/bs";
+import { FaMedal } from "react-icons/fa";
+import type { UserProfile } from "~/lib/models/user.server";
+
+export default function ProfileStats({
+  stats,
+}: {
+  stats: UserProfile["stats"];
+}) {
+  return (
+    <section className="grid grid-cols-3 gap-4 mt-8">
+      <StatCard
+        icon={<BsTools className="w-5 h-5 text-brand-500" />}
+        value={stats.completed_challenge_count}
+        label="mini-projetos concluídos"
+      />
+      <StatCard
+        icon={<BsFillHeartFill className="w-5 h-5 text-brand-500" />}
+        value={stats.received_reaction_count}
+        label="reações recebidas"
+      />
+      <StatCard
+        icon={<FaMedal className="w-5 h-5 text-brand-500" />}
+        value={stats.points}
+        label="pontos"
+      />
+    </section>
+  );
+}
+
+function StatCard({
+  icon,
+  value,
+  label,
+}: {
+  icon: React.ReactNode;
+  value: number;
+  label: string;
+}) {
+  return (
+    <div className="flex flex-col items-center gap-2 rounded-xl border border-background-200 dark:border-background-600 bg-background-50 dark:bg-background-800 p-6">
+      <div className="flex items-center gap-2">
+        {icon}
+        <span className="text-2xl font-bold dark:text-white">{value}</span>
+      </div>
+      <span className="text-xs text-gray-500 dark:text-gray-400 text-center">
+        {label}
+      </span>
+    </div>
+  );
+}

--- a/app/routes/_layout-app/_perfil/perfil_.$github_user/index.test.tsx
+++ b/app/routes/_layout-app/_perfil/perfil_.$github_user/index.test.tsx
@@ -1,0 +1,144 @@
+import { screen } from "@testing-library/react";
+import { renderWithRouter } from "~/test/render-with-router";
+import UserProfilePage from "./index";
+
+vi.mock("~/lib/models/user.server", () => ({
+  getUserProfile: vi.fn(),
+}));
+
+vi.mock("~/components/ui/tooltip", () => ({
+  default: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}));
+
+const mockProfile = {
+  user: {
+    name: "maria oliveira",
+    github_user: "mariaoliveira",
+    linkedin_user: "maria-oliveira",
+    avatar: {
+      avatar_url: "https://example.com/avatar.jpg",
+      name: "Maria Oliveira",
+      badge: "pro" as const,
+      github_user: "mariaoliveira",
+    },
+    created_at: "2024-03-10T12:00:00Z",
+  },
+  stats: {
+    points: 350,
+    completed_challenge_count: 15,
+    received_reaction_count: 60,
+  },
+  completed_challenges: [
+    {
+      id: 1,
+      submission_image_url: "https://example.com/sub1.jpg",
+      submission_url: "https://github.com/maria/project1",
+      submitted_at: "2024-06-01T12:00:00Z",
+      challenge: {
+        name: "Landing Page com Tailwind",
+        slug: "landing-page-tailwind",
+        image_url: "https://example.com/challenge1.png",
+      },
+    },
+    {
+      id: 2,
+      submission_image_url: "https://example.com/sub2.jpg",
+      submission_url: "https://github.com/maria/project2",
+      submitted_at: "2024-07-15T12:00:00Z",
+      challenge: {
+        name: "Dashboard com React",
+        slug: "dashboard-react",
+        image_url: "https://example.com/challenge2.png",
+      },
+    },
+  ],
+  certificates: [
+    {
+      id: "cert1",
+      metadata: {
+        certifiable_source_name: "Workshop React Avançado",
+        certifiable_slug: "react-avancado",
+      },
+      status: "published",
+      created_at: "2024-08-01T12:00:00Z",
+    },
+  ],
+};
+
+describe("UserProfilePage route", () => {
+  it("renders user name", async () => {
+    renderWithRouter(UserProfilePage, {
+      path: "/perfil/:github_user",
+      initialEntries: ["/perfil/mariaoliveira"],
+      loader: () => ({ profile: mockProfile }),
+    });
+
+    expect(await screen.findByText("Maria Oliveira")).toBeInTheDocument();
+  });
+
+  it("renders stats", async () => {
+    renderWithRouter(UserProfilePage, {
+      path: "/perfil/:github_user",
+      initialEntries: ["/perfil/mariaoliveira"],
+      loader: () => ({ profile: mockProfile }),
+    });
+
+    expect(await screen.findByText("350")).toBeInTheDocument();
+    expect(screen.getByText("15")).toBeInTheDocument();
+    expect(screen.getByText("60")).toBeInTheDocument();
+  });
+
+  it("renders completed challenges", async () => {
+    renderWithRouter(UserProfilePage, {
+      path: "/perfil/:github_user",
+      initialEntries: ["/perfil/mariaoliveira"],
+      loader: () => ({ profile: mockProfile }),
+    });
+
+    expect(
+      await screen.findByText("Landing Page com Tailwind"),
+    ).toBeInTheDocument();
+    expect(screen.getByText("Dashboard com React")).toBeInTheDocument();
+  });
+
+  it("renders certificates", async () => {
+    renderWithRouter(UserProfilePage, {
+      path: "/perfil/:github_user",
+      initialEntries: ["/perfil/mariaoliveira"],
+      loader: () => ({ profile: mockProfile }),
+    });
+
+    expect(
+      await screen.findByText("Workshop React Avançado"),
+    ).toBeInTheDocument();
+  });
+
+  it("renders GitHub link", async () => {
+    renderWithRouter(UserProfilePage, {
+      path: "/perfil/:github_user",
+      initialEntries: ["/perfil/mariaoliveira"],
+      loader: () => ({ profile: mockProfile }),
+    });
+
+    expect(await screen.findByText("@mariaoliveira")).toBeInTheDocument();
+  });
+
+  it("shows empty states when no challenges or certificates", async () => {
+    const emptyProfile = {
+      ...mockProfile,
+      completed_challenges: [],
+      certificates: [],
+    };
+
+    renderWithRouter(UserProfilePage, {
+      path: "/perfil/:github_user",
+      initialEntries: ["/perfil/mariaoliveira"],
+      loader: () => ({ profile: emptyProfile }),
+    });
+
+    expect(
+      await screen.findByText("Nenhum mini-projeto concluído ainda."),
+    ).toBeInTheDocument();
+    expect(screen.getByText("Nenhum certificado ainda.")).toBeInTheDocument();
+  });
+});

--- a/app/routes/_layout-app/_perfil/perfil_.$github_user/index.tsx
+++ b/app/routes/_layout-app/_perfil/perfil_.$github_user/index.tsx
@@ -1,0 +1,105 @@
+import {
+  Link,
+  isRouteErrorResponse,
+  useLoaderData,
+  useRouteError,
+} from "react-router";
+import type { LoaderFunctionArgs, MetaFunction } from "react-router";
+import invariant from "tiny-invariant";
+import { getUserProfile } from "~/lib/models/user.server";
+import { formatName } from "~/lib/utils/format-name";
+import { getOgGeneratorUrl } from "~/lib/utils/path-utils";
+import ProfileHeader from "../components/profile-header";
+import ProfileStats from "../components/profile-stats";
+import ProfileChallenges from "../components/profile-challenges";
+import ProfileCertificates from "../components/profile-certificates";
+
+export const meta: MetaFunction<typeof loader> = ({ data, params }) => {
+  if (!data?.profile) {
+    return [{ title: "Perfil não encontrado | Codante.io" }];
+  }
+
+  const { profile } = data;
+  const name = formatName(profile.user.name);
+  const title = `${name} | Codante.io`;
+  const description = `Veja o perfil de ${name} no Codante. ${profile.stats.completed_challenge_count} mini-projetos concluídos, ${profile.stats.points} pontos.`;
+  const imageUrl = getOgGeneratorUrl(name, "Perfil");
+
+  return [
+    { title },
+    { name: "description", content: description },
+    { property: "og:title", content: title },
+    { property: "og:description", content: description },
+    { property: "og:image", content: imageUrl },
+    {
+      property: "og:url",
+      content: `https://codante.io/perfil/${params.github_user}`,
+    },
+    { property: "og:type", content: "profile" },
+    { name: "twitter:card", content: "summary_large_image" },
+    { name: "twitter:title", content: title },
+    { name: "twitter:description", content: description },
+    { name: "twitter:image", content: imageUrl },
+  ];
+};
+
+export async function loader({ params }: LoaderFunctionArgs) {
+  invariant(params.github_user, "params.github_user is required");
+
+  const profile = await getUserProfile(params.github_user);
+
+  if (!profile) {
+    throw new Response("Not Found", { status: 404 });
+  }
+
+  return { profile };
+}
+
+export function ErrorBoundary() {
+  const error = useRouteError();
+
+  if (isRouteErrorResponse(error) && error.status === 404) {
+    return (
+      <main className="container mx-auto py-20 text-center">
+        <p className="mb-6 text-lg font-light text-brand">404</p>
+        <h1 className="mb-6 text-3xl font-bold font-lexend dark:text-gray-300">
+          Perfil não encontrado
+        </h1>
+        <p className="mb-10 dark:text-gray-400">
+          Não encontramos nenhum usuário com esse nome.
+        </p>
+        <Link className="text-sm font-medium text-brand" to="/">
+          <span aria-hidden="true">&larr;</span> Voltar para a Home
+        </Link>
+      </main>
+    );
+  }
+
+  return (
+    <main className="container mx-auto py-20 text-center">
+      <p className="mb-6 text-lg font-light text-brand">Erro</p>
+      <h1 className="mb-6 text-3xl font-bold font-lexend dark:text-gray-300">
+        Algo deu errado
+      </h1>
+      <Link className="text-sm font-medium text-brand" to="/">
+        <span aria-hidden="true">&larr;</span> Voltar para a Home
+      </Link>
+    </main>
+  );
+}
+
+export default function UserProfilePage() {
+  const { profile } = useLoaderData<typeof loader>();
+
+  return (
+    <main className="container mx-auto py-10">
+      <ProfileHeader user={profile.user} />
+      <ProfileStats stats={profile.stats} />
+      <ProfileChallenges
+        challenges={profile.completed_challenges}
+        githubUser={profile.user.github_user}
+      />
+      <ProfileCertificates certificates={profile.certificates} />
+    </main>
+  );
+}

--- a/app/routes/index.tsx
+++ b/app/routes/index.tsx
@@ -200,7 +200,11 @@ function Challenges() {
           <section className="grid grid-cols-1 md:grid-cols-2 gap-6 lg:grid-cols-3 xl:grid-cols-4 auto-rows-min mt-24">
             {orderedChallengeList.map((challenge) => (
               <div key={challenge.slug} className="mx-auto">
-                <ChallengeCard openInNewTab challenge={challenge} />
+                <ChallengeCard
+                  openInNewTab
+                  showAvatarHoverCard
+                  challenge={challenge}
+                />
               </div>
             ))}
           </section>


### PR DESCRIPTION
## Summary
- add the public profile page flow, including the profile API route and profile UI components
- add avatar hover cards to home and mini-projetos discovery surfaces plus a Meu Perfil menu link
- fix the login/logout re-entry edge case and improve GitHub callback error reporting

## Testing
- npx eslint app/components/_layouts/navbar/profile-menu.tsx app/components/_layouts/navbar/profile-menu.test.tsx app/components/ui/cards/challenge-card.tsx app/components/ui/cards/challenge-card.test.tsx app/components/ui/user-avatar-hover-card/index.tsx app/lib/models/user.server.ts app/lib/services/auth.server.ts app/lib/services/github-auth.server.ts app/routes/_api/user-profile/index.tsx app/routes/_landing-page/components/headline/avatars.tsx app/routes/_landing-page/components/headline/avatars.test.tsx app/routes/_layout-app/_auth/login/index.tsx app/routes/_layout-app/_auth/login/index.test.ts app/routes/_layout-app/_mini-projetos/mini-projetos/index.tsx app/routes/_layout-app/_mini-projetos/mini-projetos/featured-challenge-section.tsx app/routes/_layout-app/_perfil/components/profile-certificates.tsx app/routes/_layout-app/_perfil/components/profile-challenges.tsx app/routes/_layout-app/_perfil/components/profile-header.tsx app/routes/_layout-app/_perfil/components/profile-header.test.tsx app/routes/_layout-app/_perfil/components/profile-stats.tsx app/routes/_layout-app/_perfil/components/profile-stats.test.tsx 'app/routes/_layout-app/_perfil/perfil_.$github_user/index.tsx' 'app/routes/_layout-app/_perfil/perfil_.$github_user/index.test.tsx' app/routes/index.tsx
- npm run test:run -- 'app/components/_layouts/navbar/profile-menu.test.tsx' 'app/components/ui/cards/challenge-card.test.tsx' 'app/routes/_landing-page/components/headline/avatars.test.tsx' 'app/routes/_layout-app/_auth/login/index.test.ts' 'app/routes/_layout-app/_perfil/perfil_.$github_user/index.test.tsx'